### PR TITLE
renamed Vagrant box to new name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "precise64" # Ubuntu 12.04
+  config.vm.box = "hashicorp/precise64" # Ubuntu 12.04
 
   memory_mb = 256
 


### PR DESCRIPTION
Vagrant box name was renamed from `precise64`, which broke the Vagrant script. 
It now works as expected. 
