### PR TITLE
Updating Provisioning YML for currently available Zookeeper version

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -3,7 +3,7 @@
   sudo: yes
   vars:
     zk:
-      version: 3.4.6
+      version: 3.4.7
       mirror: http://apache.xl-mirror.nl
       dataDir: /var/lib/zookeeper
       installDir: "/opt"


### PR DESCRIPTION
On December 3, Apache release Zookeeper v3.4.7 (Release Notes: http://zookeeper.apache.org/doc/r3.4.7/releasenotes.html) which removed availability of v3.4.6 on mirrors.  During an initial provisioning of a Zookeeper cluster Ansible will fail to download v3.4.6 and thus fail establishing the cluster:

```
TASK: [Zookeeper | Ensure Zookeeper tar is downloaded] ************************ 
failed: [node-1] => {"dest": "/tmp", "failed": true, "gid": 0, "group": "root", "mode": "01777", "owner": "root", "response": "HTTP Error 404: Not Found", "size": 4096, "state": "directory", "status_code": 404, "uid": 0, "url": "http://apache.xl-mirror.nl/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz"}
msg: Request failed

FATAL: all hosts have already failed -- aborting
```

Updated the provisioning YML to the current version of Zookeeper available on the mirror (v3.4.7)
